### PR TITLE
feat: Migrate data layer to Mnesia and enhance search capabilities

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["Alashandria", "numericality"]
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # alASHandria
 
-> A library that burns all the books all the time. (In memory with ETS, if you did not get it...)
+> A library that burns all the books all the time. (In memory with Mnesia, if you did not get it...)
 
 [![Elixir](https://img.shields.io/badge/Elixir-1.17+-blueviolet.svg)](https://elixir-lang.org/)
 [![Ash Framework](https://img.shields.io/badge/Ash-3.5+-orange.svg)](https://ash-hq.org/)
@@ -27,25 +27,29 @@ Create an author and book:
 
 ```graphql
 mutation {
-  createAuthor(input: {
-    name: "Machado de Assis"
-    nationality: "BR"
-  }) {
-    result { id name }
+  createAuthor(input: { name: "Machado de Assis", nationality: "BR" }) {
+    result {
+      id
+      name
+    }
   }
 }
 
 mutation {
-  createBook(input: {
-    name: "Dom Casmurro"
-    pages: 200
-    edition: 1
-    authorId: "author-id-here"
-  }) {
+  createBook(
+    input: {
+      name: "Dom Casmurro"
+      pages: 200
+      edition: 1
+      authorId: "author-id-here"
+    }
+  ) {
     result {
       id
       name
-      author { name }
+      author {
+        name
+      }
     }
   }
 }
@@ -58,11 +62,14 @@ query {
   searchAuthors(name: "Machado", nationality: "BR") {
     id
     name
-    books { name pages }
+    books {
+      name
+      pages
+    }
   }
 }
 ```
 
 Just it, welcome.
 
-Oh, the rest of the doc 😲? Oh no... I think I burned it by accident. 
+Oh, the rest of the doc 😲? Oh no... I think I burned it by accident.

--- a/lib/alashandria/library/book.ex
+++ b/lib/alashandria/library/book.ex
@@ -1,8 +1,10 @@
 defmodule Alashandria.Library.Book do
   use Ash.Resource,
     domain: Alashandria.Library,
-    data_layer: Ash.DataLayer.Ets,
+    data_layer: Ash.DataLayer.Mnesia,
     extensions: [AshGraphql.Resource]
+
+  alias Alashandria.Library.Validations
 
   graphql do
     type :book
@@ -10,6 +12,7 @@ defmodule Alashandria.Library.Book do
     queries do
       get :get_book, :read
       list :list_books, :read
+      list :search_books, :search
     end
 
     mutations do
@@ -20,31 +23,60 @@ defmodule Alashandria.Library.Book do
   actions do
     defaults [:read]
 
+    read :search do
+      argument :name, :string, allow_nil?: true
+      argument :author, :string, allow_nil?: true
+
+      prepare fn query, _context ->
+        query
+        |> filter_by_book_name(Ash.Query.get_argument(query, :name))
+        |> filter_by_author_name(Ash.Query.get_argument(query, :author))
+      end
+    end
+
     create :create do
       accept [:name, :pages, :edition, :author_id]
       validate present([:name, :pages, :edition, :author_id])
       validate numericality(:pages, greater_than: 0)
       validate numericality(:edition, greater_than: 0)
+      validate {Validations.AuthorExists, []}
     end
   end
 
   attributes do
-    uuid_primary_key :id
+    uuid_primary_key :id do
+      public? true
+    end
 
     attribute :name, :string do
       public? true
     end
 
-    attribute :pages, :integer
+    attribute :pages, :integer do
+      public? true
+    end
 
     attribute :edition, :integer do
       public? true
     end
 
-    attribute :isbn, :string
-    attribute :description, :string
-    attribute :language, :string, default: "pt"
-    attribute :total_copies, :integer, default: 1
+    attribute :description, :string do
+      public? true
+    end
+
+    attribute :isbn, :string do
+      public? true
+    end
+
+    attribute :language, :string do
+      default "PT"
+      public? true
+    end
+
+    attribute :total_copies, :integer do
+      default 1
+      public? true
+    end
 
     timestamps()
   end
@@ -52,6 +84,48 @@ defmodule Alashandria.Library.Book do
   relationships do
     belongs_to :author, Alashandria.Library.Author do
       public? true
+      allow_nil? false
     end
+  end
+
+  defp filter_by_book_name(query, name) when name in [nil, ""], do: query
+
+  # Mnesia doesn't have support for queries with partial strings, so this query fetch all data from the base and filter the results
+  defp filter_by_book_name(query, search_term) do
+    Ash.Query.after_action(query, fn _query, results ->
+      filtered =
+        Enum.filter(results, fn author ->
+          author.name
+          |> String.downcase()
+          |> String.contains?(String.downcase(search_term))
+        end)
+
+      {:ok, filtered}
+    end)
+  end
+
+  defp filter_by_author_name(query, name) when name in [nil, ""], do: query
+
+  # Mnesia doesn't have support for queries with partial strings, so this query fetch all data from the base and filter the results
+  defp filter_by_author_name(query, search_term) do
+    query
+    |> Ash.Query.after_action(fn _query, results ->
+      loaded_books = Ash.load!(results, :author, domain: Alashandria.Library)
+
+      filtered =
+        Enum.filter(loaded_books, fn book ->
+          case book.author do
+            nil ->
+              false
+
+            author ->
+              author.name
+              |> String.downcase()
+              |> String.contains?(String.downcase(search_term))
+          end
+        end)
+
+      {:ok, filtered}
+    end)
   end
 end

--- a/lib/alashandria/library/validations/author_exists.ex
+++ b/lib/alashandria/library/validations/author_exists.ex
@@ -1,0 +1,13 @@
+defmodule Alashandria.Library.Validations.AuthorExists do
+  alias Alashandria.Library.Author
+  use Ash.Resource.Validation
+
+  def validate(changeset, _opts, _context) do
+    author_id = Ash.Changeset.get_attribute(changeset, :author_id)
+
+    case Ash.get(Author, author_id, domain: Alashandria.Library) do
+      {:ok, _} -> :ok
+      {:error, _} -> {:error, field: :author_id, message: "Author does not exist"}
+    end
+  end
+end

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -2,6 +2,8 @@ defmodule Alashandria.Application do
   use Application
 
   def start(_type, _args) do
+    setup_mnesia()
+
     children = [
       {Bandit, plug: Alashandria.Endpoint, port: 4000}
     ]
@@ -9,5 +11,10 @@ defmodule Alashandria.Application do
     opts = [strategy: :one_for_one, name: Alashandria.Supervisor]
 
     Supervisor.start_link(children, opts)
+  end
+
+  defp setup_mnesia do
+    :mnesia.create_schema([node()])
+    Ash.DataLayer.Mnesia.start(Alashandria.Library)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Alashandria.MixProject do
       {:absinthe_plug, "~> 1.5"},
       {:plug_cowboy, "~> 2.0"},
       {:bandit, "~> 1.0"},
-      {:faker, "~> 0.18", only: :test}
+      {:faker, "~> 0.18"}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]


### PR DESCRIPTION
Migrate Author and Book resources from Ash.DataLayer.Ets to Ash.DataLayer.Mnesia, improving database operations. Add public attribute visibility and default values, and introduce new search features for books and authors with support for partial string matches, addressing limitations in Mnesia's query capabilities. Implement validation to check for author existence when creating books.